### PR TITLE
Reintroduced close() to dataset.py

### DIFF
--- a/training/dataset.py
+++ b/training/dataset.py
@@ -223,6 +223,10 @@ class TFRecordDataset:
                 np.random.randint(self._np_labels.shape[0], size=[minibatch_size])
             ]
         return np.zeros([minibatch_size, 0], self.label_dtype)
+    
+    # Placeholder to close a dataset
+    def close(self):
+        pass
 
 # ----------------------------------------------------------------------------
 # Helper func for constructing a dataset object using the given options.


### PR DESCRIPTION
Hello.  The`TFRecordDataset()` no longer has a `close()` method which is required in [line 367 of `training_loop.py`](https://github.com/skyflynil/stylegan2/blob/7c7981dc1f6d61e3321bfe5b5e33d7c7e8ec9551/training/training_loop.py#L367). This raises an error once the user-defined number of `kimgs` is reached and the training session is over. This method was there in the original Nvidia's implementation but removed since 54b68ea49c357416500ce63853544111222af915. My guess is that users seldom reach the end of the training loop, so the error is not encountered that often. However, I propose to add this back for completeness and future compatibility. Thank you.